### PR TITLE
Replace $CFG->prefix usages by bracket syntax

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -98,7 +98,7 @@ if ($instanceid) {
     $debug_arraysql = enrol_attributes_plugin::arraysyntax_tosql($debug_fieldsandrules);
     debugging('arraysql= ' . print_r($debug_arraysql, true), DEBUG_DEVELOPER);
     $debug_sqlquery =
-            'SELECT DISTINCT u.id FROM '.$CFG->prefix.'user u ' . $debug_arraysql['select'] . ' WHERE ' . $debug_arraysql['where'];
+            'SELECT DISTINCT u.id FROM {user} u ' . $debug_arraysql['select'] . ' WHERE ' . $debug_arraysql['where'];
     debugging('sqlquery= ' . print_r($debug_sqlquery, true), DEBUG_DEVELOPER);
     $debug_users = $DB->get_records_sql($debug_sqlquery);
     debugging('countusers= ' . print_r(count($debug_users), true), DEBUG_DEVELOPER);

--- a/lib.php
+++ b/lib.php
@@ -219,7 +219,7 @@ class enrol_attributes_plugin extends enrol_plugin {
     }
 
     public static function process_enrolments($event = null, $instanceid = null) {
-        global $CFG, $DB;
+        global $DB;
         $nbenrolled = 0;
         $possible_unenrolments = array();
 
@@ -247,7 +247,7 @@ class enrol_attributes_plugin extends enrol_plugin {
                 continue;
             }
 
-            $select = 'SELECT DISTINCT u.id FROM '.$CFG->prefix.'user u';
+            $select = 'SELECT DISTINCT u.id FROM {user} u';
             $where = ' WHERE u.id='.$userid.' AND u.deleted=0 AND ';
             $arraysyntax = self::attrsyntax_toarray($unenrol_attributes_record->customtext1);
             $arraysql    = self::arraysyntax_tosql($arraysyntax);
@@ -276,7 +276,7 @@ class enrol_attributes_plugin extends enrol_plugin {
             $enrol_attributes_instance = new enrol_attributes_plugin();
             $enrol_attributes_instance->name = $enrol_attributes_record->name;
 
-            $select = 'SELECT DISTINCT u.id FROM '.$CFG->prefix.'user u';
+            $select = 'SELECT DISTINCT u.id FROM {user} u';
             if ($event) { // called by an event, i.e. user login
                 $userid = (int)$event->userid;
                 $where = ' WHERE u.id='.$userid;


### PR DESCRIPTION
This partially reverts commit a0b78bd7b3d417dcf08b218690150f0fa9301d3d.

Hi there Nicolas,

`$CFG->prefix` should not be hardcoded, the `{bracket}` syntax for tables is better.
