### PR TITLE
Fix failing unit tests.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -336,7 +336,8 @@ class enrol_attributes_plugin extends enrol_plugin {
         $where = preg_replace('/^1=1/', '', $where);
 
         if($where === '') {
-            $where = false;
+            // Must be FALSE in any database without causing syntax error
+            $where = '1=0';
         } else {
             $where = " ( $where ) ";
         }

--- a/settings.php
+++ b/settings.php
@@ -58,7 +58,9 @@ if ($ADMIN->fulltree) {
         $settings->add(new admin_setting_configmultiselect('enrol_attributes/profilefields',
                 get_string('profilefields', 'enrol_attributes'), get_string('profilefields_desc', 'enrol_attributes'),
                 [], $customfields));
-    } else {
+    } else if (!defined('PHPUNIT_TEST')) {
+        // The warning needs to be given only if unit tests are not running.
+        // Otherwise some core tests might fail.
         $url = new moodle_url('/user/profile/index.php');
         \core\notification::warning(get_string('no_custom_field', 'enrol_attributes',$CFG->wwwroot . '/user/profile/index.php'));
     }

--- a/tests/attributes_test.php
+++ b/tests/attributes_test.php
@@ -33,9 +33,19 @@ class attributes_testcase extends advanced_testcase
 
         $this->course = self::getDataGenerator()->create_course();
         $this->group = self::getDataGenerator()->create_group(['courseid' => $this->course->id]);
-        $this->field = self::getDataGenerator()->create_custom_profile_field(
-            ['datatype' => 'text', 'shortname' => 'testprofilefield', 'name' => 'testprofilefield']
+
+        // Create a new profile field.
+        $new_rec = array(
+            'datatype' => 'text',
+            'shortname' => 'testprofilefield',
+            'name' => 'testprofilefield'
         );
+        $DB->insert_record('user_info_field', (object)$new_rec);
+
+        // name is not searcheable in the database, it must be removed before reading.
+        unset($new_rec['name']);
+        $this->field = $DB->get_record('user_info_field', $new_rec);
+
         $this->user = self::getDataGenerator()->create_user(
             [
                 'username' => 'toto@example.com',
@@ -106,6 +116,7 @@ class attributes_testcase extends advanced_testcase
         global $DB;
         /* Removing user custom attribute */
         $DB->delete_records('user_info_data', ['userid' => $this->user->id, 'fieldid' => $this->field->id]);
+        $DB->delete_records('user_info_field', ['id' => $this->field->id]);
         /* Updating enrolments */
         enrol_attributes_plugin::process_enrolments();
     }


### PR DESCRIPTION
- Replace invalid call to self::getDataGenerator()->create_custom_profile_field(), which is not available in Moodle 3.9 by direct inserting a record inside 'user_info_field'.

- The plugin should not give a warning when phpunit tests are running to prevent failures in core unit tests.

- Fix syntax error in MySQL/MariaDB with Moodle 3.9.