### PR TITLE
[BUGFIX] Fixed json_decode argument to always be a string

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -188,7 +188,7 @@ class enrol_attributes_plugin extends enrol_plugin {
                 mtrace('+', '');
             }
 
-            $enroldetails = json_decode($enrol_attributes_record->customtext1);
+            $enroldetails = json_decode($enrol_attributes_record->customtext1 ?? '');
             if (isset($enroldetails->rules)) {
                 $rules = $enroldetails->rules;
             } else {


### PR DESCRIPTION
json_decode method expects a string as its first argument and this was not always the case when $enrol_attributes_record->customtext1 was empty it returned a NULL. Ternary operator condition added to have a fallback to an empty string when this $enrol_attributes_record->customtext1 attribute is falsy.

This bug triggers in php8.0 and above as type checking is more strict.