### PR TITLE
Fix for Undefined argv and Deprecated strpos() Issues

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -132,7 +132,7 @@ class enrol_attributes_plugin extends enrol_plugin {
         foreach ($possible_unenrolments as $id => $user_enrolment) {
             $nbpossunenrol++;
             // we only want output if runnning within the scheduled task
-            if (!$event && !$instanceid && $nbpossunenrol % 1000 === 0 && strpos($_SERVER['argv'][0], 'phpunit') === FALSE) {
+            if (!$event && !$instanceid && $nbpossunenrol % 1000 === 0 && isset($_SERVER['argv'][0]) && is_string($_SERVER['argv'][0]) && strpos($_SERVER['argv'][0], 'phpunit') === FALSE) {
                 mtrace('-', '');
             }
 
@@ -183,7 +183,7 @@ class enrol_attributes_plugin extends enrol_plugin {
         // are we to enrol anywhere?
         foreach ($enrol_attributes_records as $enrol_attributes_record) {
             $nbpossenrol++;
-            if (!$event && !$instanceid && strpos($_SERVER['argv'][0], 'phpunit') === FALSE) {
+            if (!$event && !$instanceid && isset($_SERVER['argv'][0]) && is_string($_SERVER['argv'][0]) && strpos($_SERVER['argv'][0], 'phpunit') === FALSE) {
                 // we only want output if runnning within the scheduled task
                 mtrace('+', '');
             }
@@ -249,7 +249,7 @@ class enrol_attributes_plugin extends enrol_plugin {
             }
         }
 
-        if (!$event && !$instanceid && strpos($_SERVER['argv'][0], 'phpunit') === FALSE) {
+        if (!$event && !$instanceid && isset($_SERVER['argv'][0]) && is_string($_SERVER['argv'][0]) && strpos($_SERVER['argv'][0], 'phpunit') === FALSE) {
             // we only want output if runnning within the scheduled task
             mtrace("\n" . 'enrol_attributes : ' . $nbdbqueries . ' DB queries.');
             mtrace('enrol_attributes : ' . $nbcachequeries . ' cache queries.');


### PR DESCRIPTION
This PR addresses warnings and deprecations related to accessing the argv key in $_SERVER and passing a null value to the strpos() function in PHP 8.1.

`2024/09/10 13:00:40 [error] 2304450#2304450: *249549 FastCGI sent in stderr: "PHP message: PHP Warning:  Undefined array key "argv" in /example.com/public_html/enrol/attributes/lib.php on line 252PHP message: PHP Warning:  Trying to access array offset on value of type null in /example.com/public_html/enrol/attributes/lib.php on line 252PHP message: PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /example.com/public_html/enrol/attributes/lib.php on line 252" while reading upstream, client: 23.88.105.37, server: example.com, request: "GET /admin/cron.php?password=... HTTP/1.1", upstream: "fastcgi://unix:/run/php/php8.1-fpm-example.com.sock:", host: "example.com"`

## Issues:

1. PHP Warning: Undefined array key "argv" — Occurs when trying to access a non-existent argv key in the $_SERVER superglobal.
2. PHP Warning: Trying to access array offset on value of type null — Triggered when attempting to access an array index that is null.
3. PHP Deprecated: strpos(): Passing null to parameter # 1 ($haystack) of type string is deprecated — Occurs when null is passed as the first argument to strpos(), which is deprecated in PHP 8.1.

## Changes made:

1. Added a check to ensure that $_SERVER['argv'] is set and not null before accessing it.
2. Replaced the strpos() call with a safer approach, handling potential null values.