### PR TITLE
#65 - No longer displays no profile fields message if plugin is disabled.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -75,7 +75,7 @@ if ($ADMIN->fulltree) {
         $settings->add(new admin_setting_configmultiselect('enrol_attributes/profilefields',
                 get_string('profilefields', 'enrol_attributes'), get_string('profilefields_desc', 'enrol_attributes'),
                 [], $customfields));
-    } else if (!(defined('PHPUNIT_TEST') && PHPUNIT_TEST)) {
+    } else if (!(defined('PHPUNIT_TEST') && PHPUNIT_TEST) && enrol_is_enabled('attributes')) {
         // The warning needs to be given only if unit tests are not running.
         // Otherwise some core tests might fail.
         \core\notification::warning(get_string('no_custom_field', 'enrol_attributes',$CFG->wwwroot . '/user/profile/index.php'));
@@ -92,4 +92,3 @@ if ($ADMIN->fulltree) {
                 PARAM_TEXT, 60, 10));
     }
 }
-


### PR DESCRIPTION
This addresses the issue described in #65.