### PR TITLE
Add new event observers for profile field updates

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -22,7 +22,6 @@
  */
 
 $observers = array(
-
         array(
                 'eventname'   => '\core\event\user_loggedin',
                 'callback'    => 'enrol_attributes_plugin::process_login',
@@ -30,6 +29,25 @@ $observers = array(
                 'internal'    => true,
                 'priority'    => 9999,
         ),
-
+        array(
+                'eventname'   => '\core\event\user_updated',
+                'callback'    => 'enrol_attributes_plugin::handle_profile_update',
+                'includefile' => '/enrol/attributes/lib.php',
+                'internal'    => true,
+                'priority'    => 9999,
+        ),
+        array(
+                'eventname'   => '\core\event\user_info_field_updated',
+                'callback'    => 'enrol_attributes_plugin::handle_profile_update',
+                'includefile' => '/enrol/attributes/lib.php',
+                'internal'    => true,
+                'priority'    => 9999,
+        ),
+        array(
+                'eventname'   => '\core\event\user_info_category_updated',
+                'callback'    => 'enrol_attributes_plugin::handle_profile_update',
+                'includefile' => '/enrol/attributes/lib.php',
+                'internal'    => true,
+                'priority'    => 9999,
+        ),
 );
-


### PR DESCRIPTION
This update ensures that when a user's profile field is modified and no longer  meets the enrollment conditions, the user is either unenrolled or suspended  from the course based on the plugin configuration